### PR TITLE
Add burn AP Graves build

### DIFF
--- a/builds/burn-ap-graves.json
+++ b/builds/burn-ap-graves.json
@@ -1,0 +1,95 @@
+{
+    "champion": "Graves",
+    "sanitizedName": "graves",
+    "buildId": 1,
+    "icon": "graves.jpg",
+    "name": "AP Burn",
+    "info": {
+      "description": "AP burn Graves build.",
+      "tags": [
+        "AP",
+        "Poke", 
+        "Fun"
+      ]
+    },
+    "summonerSpells": [
+      "ignite",
+      "flash"
+    ],
+    "quickSkillOrder": "wqe",
+    "runes": {
+      "major": {
+        "configuration": [
+          "Dark Harvest",
+          "Sudden Impact",
+          "Eyeball Collection",
+          "Ultimate Hunter"
+        ],
+        "tree": "Domination"
+      },
+      "minor": {
+        "configuration": [
+          "Transcendence",
+          "Scorch"
+        ],
+        "tree": "Sorcery"
+      },
+      "passive": {
+        "configuration": [
+          "haste",
+          "adaptive",
+          "hp"
+        ],
+        "tree": "Passive"
+      }
+    },
+    "itemSets": [
+      {
+        "description": "Starting items",
+        "items": [
+          "Bandleglass Mirror",
+          "Amplifying Tome"
+        ]
+      },
+      {
+        "description": "Rush this in this order",
+        "items": [
+          "Imperial Mandate",
+          "Liandry's Anguish",
+          "Demonic Embrace"
+        ]
+      },
+      {
+        "description": "Boots",
+        "items": [
+          "Ionian Boots of Lucidity"
+        ]
+      },
+      {
+        "description": "Good items",
+        "items": [
+          "Horizon Focus",
+          "Shadowflame"
+        ]
+      },
+      {
+        "description": "Situational items",
+        "items": [
+          "Lord Dominik's Regards",
+          "Serpent's Fang",
+          "Morellonomicon"
+        ]
+      },
+      {
+        "description": "Example final build",
+        "items": [
+          "Ionian Boots of Lucidity",
+          "Imperial Mandate",
+          "Liandry's Anguish",
+          "Demonic Embrace",
+          "Horizon Focus",
+          "Void Staff"
+        ]
+      }
+    ]
+  }


### PR DESCRIPTION
This is the burn version of AP Graves. I find that the Luden's version has too long of a CD on W. For the burn build, my playstyle is spam W and R off cooldown to apply the burn effects from Liandry's and Demonic Embrace. 

Starting items:
- Bandleglass Mirror
- Amplifying Tome

Rush:
- Imperial Mandate - this item is extremely cheap (only 915 gold after first back)
- Liandry's Anguish - burn core
- Demonic Embrace - burn core

Situational:
- Morellonomicon - if they have any sources of healing
- Serpent's Fang - if they have significant sources of shielding
- Lord Dominik's Regard - if they have a lot of tanks

Boots
- Ionian Boots of Lucidity

Runes:
- Dark Harvest, Sudden Impact, Eyeball Collection, Ultimate Hunter
- Transcendence, Scorch

Final Build (most of my games):
- Ionian Boots of Lucidity
- Imperial Mandate (can maybe sell later, but I usually don't go that far into the game)
- Liandry's Anguish
- Demonic Embrace
- Horizon Focus / Morellonomicon
- Void Staff

Cred: LuckierLion
